### PR TITLE
Improve error message when write() returns None

### DIFF
--- a/examples/path_or_file_like/src/lib.rs
+++ b/examples/path_or_file_like/src/lib.rs
@@ -4,7 +4,7 @@ use pyo3_file::PyFileLikeObject;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use std::fs::File;
-use std::io::Read;
+use std::io::{Read, Write};
 
 /// Represents either a path `File` or a file-like object `FileLike`
 #[derive(Debug)]
@@ -34,7 +34,7 @@ impl FileOrFileLike {
 
 #[pyfunction]
 /// Opens a file or file-like, and reads it to string.
-fn accepts_path_or_file_like(path_or_file_like: PyObject) -> PyResult<String> {
+fn accepts_path_or_file_like_read(path_or_file_like: PyObject) -> PyResult<String> {
     match FileOrFileLike::from_pyobject(path_or_file_like) {
         Ok(f) => match f {
             FileOrFileLike::File(s) => {
@@ -57,9 +57,24 @@ fn accepts_path_or_file_like(path_or_file_like: PyObject) -> PyResult<String> {
     }
 }
 
+#[pyfunction]
+/// Opens a file or file-like, and write a string to it.
+fn accepts_file_like_write(file_like: PyObject) -> PyResult<()> {
+    // is a file-like
+    match PyFileLikeObject::with_requirements(file_like, false, true, false) {
+        Ok(mut f) => {
+            println!("Its a file-like object");
+            f.write_all(b"Hello, world!")?;
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
 #[pymodule]
 fn path_or_file_like(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(accepts_path_or_file_like))?;
+    m.add_wrapped(wrap_pyfunction!(accepts_path_or_file_like_read))?;
+    m.add_wrapped(wrap_pyfunction!(accepts_file_like_write))?;
 
     Ok(())
 }

--- a/examples/path_or_file_like/tests/test_path_or_file_like.py
+++ b/examples/path_or_file_like/tests/test_path_or_file_like.py
@@ -2,7 +2,7 @@ import pytest
 import io
 from pathlib import Path
 
-from path_or_file_like import accepts_path_or_file_like
+from path_or_file_like import accepts_path_or_file_like_read, accepts_file_like_write
 
 
 @pytest.fixture
@@ -11,25 +11,45 @@ def small_sample() -> str:
     return str(p.joinpath('sample.txt'))
 
 
-def test_it_works_on_io_object(small_sample):
+def test_it_reads_from_io_object(small_sample):
     with open(small_sample, "rb") as o:
         r = o.read()
 
-    assert accepts_path_or_file_like(io.BytesIO(r)) == "Hello World!"
+    assert accepts_path_or_file_like_read(io.BytesIO(r)) == "Hello World!"
 
-def test_it_works_on_textio_object(small_sample):
+def test_it_reads_from_textio_object(small_sample):
     with open(small_sample, "rt") as o:
         r = o.read()
 
-    assert accepts_path_or_file_like(io.StringIO(r)) == "Hello World!"
+    assert accepts_path_or_file_like_read(io.StringIO(r)) == "Hello World!"
 
-def test_it_works_on_file_backed_object(small_sample):
+def test_it_reads_from_file_backed_object(small_sample):
     with open(small_sample, "rb") as o:
-        assert accepts_path_or_file_like(o) == "Hello World!"
+        assert accepts_path_or_file_like_read(o) == "Hello World!"
 
 
 def test_it_fails_on_non_file_object():
     with pytest.raises(TypeError):
-        accepts_path_or_file_like(3)
+        accepts_path_or_file_like_read(3)
 
 
+def test_it_fails_when_write_returns_none():
+    class FileLike:
+
+        def write(self, _data):
+            return None
+
+    with pytest.raises(OSError, match=r'write\(\) returned None, expected number of bytes written'):
+        accepts_file_like_write(FileLike())
+
+
+def test_it_writes_to_io_object():
+    f = io.BytesIO()
+    accepts_file_like_write(f)
+    assert f.getvalue() == b"Hello, world!"
+
+
+def test_it_writes_to_textio_object():
+    f = io.StringIO()
+    accepts_file_like_write(f)
+    assert f.getvalue() == "Hello, world!"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,12 +85,13 @@ impl Read for PyFileLikeObject {
             if self.is_text_io {
                 if buf.len() < 4 {
                     return Err(io::Error::new(
-                        io::ErrorKind::Other, "buffer size must be at least 4 bytes"
+                        io::ErrorKind::Other,
+                        "buffer size must be at least 4 bytes",
                     ));
                 }
                 let res = self
                     .inner
-                    .call_method(py, "read", (buf.len()/4,), None)
+                    .call_method(py, "read", (buf.len() / 4,), None)
                     .map_err(pyerr_to_io_err)?;
                 let pystring: &PyString = res
                     .downcast(py)
@@ -129,6 +130,13 @@ impl Write for PyFileLikeObject {
                 .inner
                 .call_method(py, "write", (arg,), None)
                 .map_err(pyerr_to_io_err)?;
+
+            if number_bytes_written.is_none(py) {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "write() returned None, expected number of bytes written",
+                ));
+            }
 
             number_bytes_written.extract(py).map_err(pyerr_to_io_err)
         })


### PR DESCRIPTION
Improve error message when write() returns None

Previously this just triggered
a vaguer "can't extract integer from None object" error
