### PR TITLE
Misc Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking Changes
+
+- `PyFileLikeObject::new` and `PyFileLikeObject::require` now take a `&PyAny`
+  instead of a `PyObject`
+
+### Added
+
+- `PyFileLikeObject` now implements `FromPyObject`/`ToPyObject`, which allows
+  it to be used directly as an argument to a pyfunction or as a return value
+- New constructor `PyFileLikeObject::with_rw_seek` which takes const generic
+  arguments to specify whether the object should be readable, writable and
+  seekable, which can be used in `#[pyo3(from_py_with)]` when declaring the
+  pyfunction or in a type deriving `FromPyObject`
+- New functions `PyFileLikeObject::check_readable`,
+  `PyFileLikeObject::check_writable` and `PyFileLikeObject::check_seekable`
+  which can be used to check whether the object is readable, writable or
+  seekable, respectively.
+- `io::Error`s returned by the Read/Write/Seek implementations for
+  `PyFileLikeObject` now pass along the original python exception, and attempt
+  to set the error kind based on the `errno` field of the python exception, if
+  present.
+- `Read`, `Write`, and `Seek` are now additionally implemented for
+  `&PyFileLikeObject` since they use the GIL for interior mutability.
+- `PyFileLikeObject` now implements `Clone`, and provides a `clone_ref` method
+  which can be used to clone the object more efficiently when already holding
+  the GIL.
+- New function `PyFileLikeObject::fileno` which attempts to call the fileno
+  method on the underlying python object, and returns the result as a `i64` if
+  successful.
+- Add support for pyo3 0.20
+
+### Fixes
+
+- The `Read` implementation for `PyFileLikeObject` will now return errors
+  rather than panicking if the underlying python object returns an unexpected
+  type from the `read` python method.
+- The `Write` implementation for `PyFileLikeObject` will now return errors
+  rather than panicking when attempting to write non-utf8 bytes to a textio
+  object.
+
+
+## [0.7.0] - 2023-06-26
+
+- Switch to GH actions by @omerbenamram in #3
+- Add textio support to PyFileLikeObject by @ethanhs in #4
+- Divide actually used buffer size by 4 for TextIO by @smheidrich in #7
+- Add support for pyo3 0.19 by @jelmer in #11
+- Improve error message when write() returns None by @jelmer in #10
+- Added a crates io publishing workflow for tags by @ohadravid in #12
+
 ## [0.5.0] - 2022-04-16
 
 - Update to PyO3 0.16

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Omer Ben-Amram <omerbenamram@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-pyo3 = { version = ">=0.18.1,<0.20" }
+pyo3 = { version = ">=0.18.1,<0.21" }
 
 [dev-dependencies]
 skeptic = "0.13.7"

--- a/README.md
+++ b/README.md
@@ -27,66 +27,47 @@ We could use `pyo3_file` to extend an existing a `pyo3` module.
 
 ```rust
 use pyo3_file::PyFileLikeObject;
-use pyo3::types::PyString;
 
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use std::io::Read;
 use std::fs::File;
+use std::path::PathBuf;
 
 /// Represents either a path `File` or a file-like object `FileLike`
-#[derive(Debug)]
+#[derive(Debug, FromPyObject)]
 enum FileOrFileLike {
-    File(String),
-    FileLike(PyFileLikeObject),
-}
-
-impl FileOrFileLike {
-    pub fn from_pyobject(path_or_file_like: PyObject) -> PyResult<FileOrFileLike> {
-        Python::with_gil(|py| {
-            // is a path
-            if let Ok(string_ref) = path_or_file_like.cast_as::<PyString>(py) {
-                return Ok(FileOrFileLike::File(
-                    string_ref.to_string_lossy().to_string(),
-                ));
-            }
-
-            // is a file-like
-            match PyFileLikeObject::with_requirements(path_or_file_like, true, false, true) {
-                Ok(f) => Ok(FileOrFileLike::FileLike(f)),
-                Err(e) => Err(e)
-            }
-        })
-    }
+    #[pyo3(annotation = "str")]
+    FileName(PathBuf),
+    #[pyo3(annotation = "file-like")]
+    FileLike(
+        #[pyo3(from_py_with = "PyFileLikeObject::with_rw_seek::<true, false, true>")]
+        PyFileLikeObject
+    ),
 }
 
 #[pyfunction]
 /// Opens a file or file-like, and reads it to string.
 fn accepts_path_or_file_like(
-    path_or_file_like: PyObject,
+    f: FileOrFileLike,
 ) -> PyResult<String> {
-    Python::with_gil(|py| {
-        match FileOrFileLike::from_pyobject(path_or_file_like) {
-            Ok(f) => match f {
-                FileOrFileLike::File(s) => {
-                    println!("It's a file! - path {}", s);
-                    let mut f = File::open(s)?;
-                    let mut string = String::new();
+    match f {
+        FileOrFileLike::FileName(s) => {
+            println!("It's a file! - path {}", s.display());
+            let mut f = File::open(s)?;
+            let mut string = String::new();
 
-                    let read = f.read_to_string(&mut string);
-                    Ok(string)
-                }
-                FileOrFileLike::FileLike(mut f) => {
-                    println!("Its a file-like object");
-                    let mut string = String::new();
-
-                    let read = f.read_to_string(&mut string);
-                    Ok(string)
-                }
-            },
-            Err(e) => Err(e),
+            let _read = f.read_to_string(&mut string);
+            Ok(string)
         }
-    })
+        FileOrFileLike::FileLike(mut f) => {
+            println!("Its a file-like object");
+            let mut string = String::new();
+
+            let _read = f.read_to_string(&mut string);
+            Ok(string)
+        }
+    }
 }
 
 #[pymodule]

--- a/examples/path_or_file_like/Cargo.lock
+++ b/examples/path_or_file_like/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-file"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "pyo3",
  "skeptic",

--- a/examples/path_or_file_like/src/lib.rs
+++ b/examples/path_or_file_like/src/lib.rs
@@ -1,74 +1,54 @@
-use pyo3::types::PyString;
 use pyo3_file::PyFileLikeObject;
 
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use std::fs::File;
 use std::io::{Read, Write};
+use std::path::PathBuf;
 
 /// Represents either a path `File` or a file-like object `FileLike`
-#[derive(Debug)]
+#[derive(Debug, FromPyObject)]
 enum FileOrFileLike {
-    File(String),
-    FileLike(PyFileLikeObject),
-}
-
-impl FileOrFileLike {
-    pub fn from_pyobject(path_or_file_like: PyObject) -> PyResult<FileOrFileLike> {
-        Python::with_gil(|py| {
-            // is a path
-            if let Ok(string_ref) = path_or_file_like.downcast::<PyString>(py) {
-                return Ok(FileOrFileLike::File(
-                    string_ref.to_string_lossy().to_string(),
-                ));
-            }
-
-            // is a file-like
-            match PyFileLikeObject::with_requirements(path_or_file_like, true, false, true) {
-                Ok(f) => Ok(FileOrFileLike::FileLike(f)),
-                Err(e) => Err(e),
-            }
-        })
-    }
+    #[pyo3(annotation = "path")]
+    FileName(PathBuf),
+    #[pyo3(annotation = "file-like")]
+    FileLike(
+        #[pyo3(from_py_with = "PyFileLikeObject::with_rw_seek::<true, false, true>")]
+        PyFileLikeObject,
+    ),
 }
 
 #[pyfunction]
 /// Opens a file or file-like, and reads it to string.
-fn accepts_path_or_file_like_read(path_or_file_like: PyObject) -> PyResult<String> {
-    match FileOrFileLike::from_pyobject(path_or_file_like) {
-        Ok(f) => match f {
-            FileOrFileLike::File(s) => {
-                println!("It's a file! - path {}", s);
-                let mut f = File::open(s)?;
-                let mut string = String::new();
+fn accepts_path_or_file_like_read(f: FileOrFileLike) -> PyResult<String> {
+    match f {
+        FileOrFileLike::FileName(s) => {
+            println!("It's a file! - path {}", s.display());
+            let mut f = File::open(s)?;
+            let mut string = String::new();
 
-                f.read_to_string(&mut string)?;
-                Ok(string)
-            }
-            FileOrFileLike::FileLike(mut f) => {
-                println!("Its a file-like object");
-                let mut string = String::new();
+            f.read_to_string(&mut string)?;
+            Ok(string)
+        }
+        FileOrFileLike::FileLike(mut f) => {
+            println!("Its a file-like object");
+            let mut string = String::new();
 
-                f.read_to_string(&mut string)?;
-                Ok(string)
-            }
-        },
-        Err(e) => Err(e),
+            f.read_to_string(&mut string)?;
+            Ok(string)
+        }
     }
 }
 
 #[pyfunction]
 /// Opens a file or file-like, and write a string to it.
-fn accepts_file_like_write(file_like: PyObject) -> PyResult<()> {
-    // is a file-like
-    match PyFileLikeObject::with_requirements(file_like, false, true, false) {
-        Ok(mut f) => {
-            println!("Its a file-like object");
-            f.write_all(b"Hello, world!")?;
-            Ok(())
-        }
-        Err(e) => Err(e),
-    }
+fn accepts_file_like_write(
+    #[pyo3(from_py_with = "PyFileLikeObject::with_rw_seek::<false, true, false>")]
+    mut file_like: PyFileLikeObject,
+) -> PyResult<()> {
+    println!("Its a file-like object");
+    file_like.write_all(b"Hello, world!")?;
+    Ok(())
 }
 
 #[pymodule]

--- a/examples/path_or_file_like/tests/test_path_or_file_like.py
+++ b/examples/path_or_file_like/tests/test_path_or_file_like.py
@@ -1,5 +1,6 @@
 import pytest
 import io
+import tempfile
 from pathlib import Path
 
 from path_or_file_like import accepts_path_or_file_like_read, accepts_file_like_write
@@ -43,6 +44,12 @@ def test_it_fails_when_write_returns_none():
         accepts_file_like_write(FileLike())
 
 
+def test_write_non_writable_file(small_sample):
+    with open(small_sample, "rb") as o:
+        with pytest.raises(TypeError, match=r'object is not writable'):
+            accepts_file_like_write(o)
+
+
 def test_it_writes_to_io_object():
     f = io.BytesIO()
     accepts_file_like_write(f)
@@ -53,3 +60,16 @@ def test_it_writes_to_textio_object():
     f = io.StringIO()
     accepts_file_like_write(f)
     assert f.getvalue() == "Hello, world!"
+
+
+def test_it_writes_to_file():
+    with tempfile.TemporaryFile() as f:
+        accepts_file_like_write(f)
+        f.seek(0)
+        assert f.read() == b"Hello, world!"
+
+def test_it_writes_to_text_file():
+    with tempfile.TemporaryFile("wt+", encoding="utf8") as f:
+        accepts_file_like_write(f)
+        f.seek(0)
+        assert f.read() == "Hello, world!"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,46 @@
 use pyo3::{exceptions::PyTypeError, prelude::*};
 
-use pyo3::types::{PyBytes, PyString, PyType};
+use pyo3::types::{PyBytes, PyString};
 
+use pyo3::once_cell::GILOnceCell;
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PyFileLikeObject {
     inner: PyObject,
     is_text_io: bool,
+}
+
+impl<'a> FromPyObject<'a> for PyFileLikeObject {
+    fn extract(ob: &'a PyAny) -> PyResult<Self> {
+        Self::new(ob)
+    }
+}
+
+impl ToPyObject for PyFileLikeObject {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        self.inner.clone_ref(py)
+    }
+}
+
+impl IntoPy<PyObject> for PyFileLikeObject {
+    fn into_py(self, _py: Python<'_>) -> PyObject {
+        self.inner
+    }
+}
+
+fn text_io_base_type(py: Python<'_>) -> PyResult<&'_ PyAny> {
+    static TEXT_IO_BASE_TYPE: GILOnceCell<PyObject> = GILOnceCell::new();
+
+    let obj: &PyObject = TEXT_IO_BASE_TYPE.get_or_try_init(py, || -> PyResult<PyObject> {
+        let io = PyModule::import(py, "io")?;
+        let base_type = io.getattr("TextIOBase")?;
+        let base_type: PyObject = base_type.into();
+        Ok(base_type)
+    })?;
+
+    Ok(obj.as_ref(py))
 }
 
 /// Wraps a `PyObject`, and implements read, seek, and write for it.
@@ -16,111 +48,206 @@ impl PyFileLikeObject {
     /// Creates an instance of a `PyFileLikeObject` from a `PyObject`.
     /// To assert the object has the required methods methods,
     /// instantiate it with `PyFileLikeObject::require`
-    pub fn new(object: PyObject) -> PyResult<Self> {
-        Python::with_gil(|py| {
-            let io = PyModule::import(py, "io")?;
-            let text_io = io.getattr("TextIOBase")?;
+    pub fn new(object: &PyAny) -> PyResult<Self> {
+        let py = object.py();
+        let text_io_base_type = text_io_base_type(py)?;
+        let is_text_io = object.is_instance(text_io_base_type)?;
 
-            let text_io_type = text_io.extract::<&PyType>()?;
-            let is_text_io = object.as_ref(py).is_instance(text_io_type)?;
-
-            Ok(PyFileLikeObject {
-                inner: object,
-                is_text_io,
-            })
+        Ok(PyFileLikeObject {
+            inner: object.into(),
+            is_text_io,
         })
+    }
+
+    /// Function to create and validate a `PyFileLikeObject`.
+    ///
+    /// This uses const generics, in order to be usable for `pyo3(from_py_with = "...")`
+    ///
+    /// ```rust
+    /// use std::io::Read;
+    /// use pyo3::prelude::*;
+    /// use pyo3_file::PyFileLikeObject;
+    ///
+    /// #[pyfunction]
+    /// fn my_method(
+    ///     #[pyo3(from_py_with = "PyFileLikeObject::with_rw_seek::<false, true, false>")]
+    ///     mut file: PyFileLikeObject
+    /// ) -> PyResult<()> {
+    ///    let mut buf = [0; 1024];
+    ///    let n = file.read(&mut buf)?;
+    ///    println!("Read bytes: {:?}", &buf[..n]);
+    /// Ok(())
+    /// }
+    /// ```
+    pub fn with_rw_seek<const READ: bool, const WRITE: bool, const SEEK: bool>(
+        object: &PyAny,
+    ) -> PyResult<Self> {
+        Self::with_requirements(object, READ, WRITE, SEEK)
     }
 
     /// Same as `PyFileLikeObject::new`, but validates that the underlying
     /// python object has a `read`, `write`, and `seek` methods in respect to parameters.
     /// Will return a `TypeError` if object does not have `read`, `seek`, and `write` methods.
     pub fn with_requirements(
-        object: PyObject,
+        object: &PyAny,
         read: bool,
         write: bool,
         seek: bool,
     ) -> PyResult<Self> {
-        Python::with_gil(|py| {
-            if read && object.getattr(py, "read").is_err() {
-                return Err(PyErr::new::<PyTypeError, _>(
-                    "Object does not have a .read() method.",
-                ));
-            }
+        let py = object.py();
+        let this = Self::new(object)?;
+        if read {
+            this.check_readable(py)?;
+        }
 
-            if seek && object.getattr(py, "seek").is_err() {
-                return Err(PyErr::new::<PyTypeError, _>(
-                    "Object does not have a .seek() method.",
-                ));
-            }
+        if seek {
+            this.check_seekable(py)?;
+        }
 
-            if write && object.getattr(py, "write").is_err() {
-                return Err(PyErr::new::<PyTypeError, _>(
-                    "Object does not have a .write() method.",
-                ));
-            }
+        if write {
+            this.check_writable(py)?;
+        }
 
-            PyFileLikeObject::new(object)
-        })
+        Ok(this)
+    }
+
+    /// Makes a clone of self.
+    ///
+    /// This creates another pointer to the same object, increasing its reference count.
+    ///
+    /// You should prefer using this method over [`Clone`] if you happen to be holding the GIL already.
+    pub fn clone_ref(&self, py: Python<'_>) -> Self {
+        Self {
+            inner: self.inner.clone_ref(py),
+            is_text_io: self.is_text_io,
+        }
+    }
+
+    /// Checks if the underlying python object has a `read` method, and that it is readable.
+    pub fn check_readable(&self, py: Python<'_>) -> PyResult<()> {
+        let object = self.inner.as_ref(py);
+        if object.getattr(pyo3::intern!(py, "read")).is_err() {
+            return Err(PyTypeError::new_err("object does not have a read() method"));
+        }
+        let readable_res = object
+            .call_method0(pyo3::intern!(py, "readable"))
+            .and_then(|res| res.is_true());
+        if matches!(readable_res, Ok(false)) {
+            return Err(PyTypeError::new_err("object is not readable"));
+        }
+        Ok(())
+    }
+
+    /// Checks if the underlying python object has a `write` method, and that it is writable.
+    pub fn check_writable(&self, py: Python<'_>) -> PyResult<()> {
+        let object = self.inner.as_ref(py);
+        if object.getattr(pyo3::intern!(py, "write")).is_err() {
+            return Err(PyTypeError::new_err(
+                "object does not have a write() method",
+            ));
+        }
+        let writable_res = object
+            .call_method0(pyo3::intern!(py, "writable"))
+            .and_then(|res| res.is_true());
+        if matches!(writable_res, Ok(false)) {
+            return Err(PyTypeError::new_err("object is not writable"));
+        }
+        Ok(())
+    }
+
+    /// Checks if the underlying python object has a `seek` method, and that it is seekable.
+    pub fn check_seekable(&self, py: Python<'_>) -> PyResult<()> {
+        let object = self.inner.as_ref(py);
+        if object.getattr(pyo3::intern!(py, "seek")).is_err() {
+            return Err(PyTypeError::new_err("object does not have a seek() method"));
+        }
+        let seekable_res = object
+            .call_method0(pyo3::intern!(py, "seekable"))
+            .and_then(|res| res.is_true());
+        if matches!(seekable_res, Ok(false)) {
+            return Err(PyTypeError::new_err("object is not seekable"));
+        }
+        Ok(())
+    }
+
+    /// Try to get the underlying fileno of the python object.
+    pub fn fileno(&self, py: Python<'_>) -> PyResult<i64> {
+        let fileno_result = self.inner.call_method0(py, pyo3::intern!(py, "fileno"))?;
+        fileno_result.extract::<i64>(py)
     }
 }
 
-/// Extracts a string repr from, and returns an IO error to send back to rust.
-fn pyerr_to_io_err(e: PyErr) -> io::Error {
-    Python::with_gil(|py| {
-        let e_as_object: PyObject = e.into_py(py);
-
-        match e_as_object.call_method(py, "__str__", (), None) {
-            Ok(repr) => match repr.extract::<String>(py) {
-                Ok(s) => io::Error::new(io::ErrorKind::Other, s),
-                Err(_e) => io::Error::new(io::ErrorKind::Other, "An unknown error has occurred"),
-            },
-            Err(_) => io::Error::new(io::ErrorKind::Other, "Err doesn't have __str__"),
-        }
-    })
+/// Create a rust io::Error from a python exception
+fn pyerr_to_io_err(py: Python<'_>, e: PyErr) -> io::Error {
+    let e_as_object = e.value(py);
+    let kind = match e_as_object
+        .getattr(pyo3::intern!(py, "errno"))
+        .and_then(PyAny::extract)
+    {
+        Ok(errno) => io::Error::from_raw_os_error(errno).kind(),
+        Err(..) => io::ErrorKind::Other,
+    };
+    io::Error::new(kind, e)
 }
 
-impl Read for PyFileLikeObject {
+impl Read for &PyFileLikeObject {
     fn read(&mut self, mut buf: &mut [u8]) -> Result<usize, io::Error> {
         Python::with_gil(|py| {
-            if self.is_text_io {
+            // Pre-declare, so bytes can reference it
+            let res: PyObject;
+            let bytes = if self.is_text_io {
                 if buf.len() < 4 {
                     return Err(io::Error::new(
-                        io::ErrorKind::Other,
+                        io::ErrorKind::InvalidInput,
                         "buffer size must be at least 4 bytes",
                     ));
                 }
-                let res = self
+                res = self
                     .inner
-                    .call_method(py, "read", (buf.len() / 4,), None)
-                    .map_err(pyerr_to_io_err)?;
-                let pystring: &PyString = res
-                    .downcast(py)
-                    .expect("Expecting to be able to downcast into str from read result.");
-                let bytes = pystring.to_str().unwrap().as_bytes();
-                buf.write_all(bytes)?;
-                Ok(bytes.len())
+                    .call_method1(py, "read", (buf.len() / 4,))
+                    .map_err(|e| pyerr_to_io_err(py, e))?;
+                let string: &str = res.extract(py).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        "read() on text-based objects should return a unicode string",
+                    )
+                })?;
+                string.as_bytes()
             } else {
-                let res = self
+                res = self
                     .inner
-                    .call_method(py, "read", (buf.len(),), None)
-                    .map_err(pyerr_to_io_err)?;
-                let pybytes: &PyBytes = res
-                    .downcast(py)
-                    .expect("Expecting to be able to downcast into bytes from read result.");
-                let bytes = pybytes.as_bytes();
-                buf.write_all(bytes)?;
-                Ok(bytes.len())
-            }
+                    .call_method1(py, "read", (buf.len(),))
+                    .map_err(|e| pyerr_to_io_err(py, e))?;
+                let bytes: &[u8] = res.extract(py).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::Other,
+                        "read() on binary objects should return a bytes object",
+                    )
+                })?;
+                bytes
+            };
+            buf.write_all(bytes)?;
+            Ok(bytes.len())
         })
     }
 }
 
-impl Write for PyFileLikeObject {
+impl Read for PyFileLikeObject {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
+        <&PyFileLikeObject>::read(&mut &*self, buf)
+    }
+}
+
+impl Write for &PyFileLikeObject {
     fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
         Python::with_gil(|py| {
             let arg = if self.is_text_io {
-                let s = std::str::from_utf8(buf)
-                    .expect("Tried to write non-utf8 data to a TextIO object.");
+                let s = std::str::from_utf8(buf).map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "Can only write utf8 data to a TextIO object",
+                    )
+                })?;
                 PyString::new(py, s).to_object(py)
             } else {
                 PyBytes::new(py, buf).to_object(py)
@@ -128,8 +255,8 @@ impl Write for PyFileLikeObject {
 
             let number_bytes_written = self
                 .inner
-                .call_method(py, "write", (arg,), None)
-                .map_err(pyerr_to_io_err)?;
+                .call_method1(py, "write", (arg,))
+                .map_err(|e| pyerr_to_io_err(py, e))?;
 
             if number_bytes_written.is_none(py) {
                 return Err(io::Error::new(
@@ -138,7 +265,9 @@ impl Write for PyFileLikeObject {
                 ));
             }
 
-            number_bytes_written.extract(py).map_err(pyerr_to_io_err)
+            number_bytes_written
+                .extract(py)
+                .map_err(|e| pyerr_to_io_err(py, e))
         })
     }
 
@@ -146,14 +275,24 @@ impl Write for PyFileLikeObject {
         Python::with_gil(|py| {
             self.inner
                 .call_method(py, "flush", (), None)
-                .map_err(pyerr_to_io_err)?;
+                .map_err(|e| pyerr_to_io_err(py, e))?;
 
             Ok(())
         })
     }
 }
 
-impl Seek for PyFileLikeObject {
+impl Write for PyFileLikeObject {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
+        <&PyFileLikeObject>::write(&mut &*self, buf)
+    }
+
+    fn flush(&mut self) -> Result<(), io::Error> {
+        <&PyFileLikeObject>::flush(&mut &*self)
+    }
+}
+
+impl Seek for &PyFileLikeObject {
     fn seek(&mut self, pos: SeekFrom) -> Result<u64, io::Error> {
         Python::with_gil(|py| {
             let (whence, offset) = match pos {
@@ -164,10 +303,16 @@ impl Seek for PyFileLikeObject {
 
             let new_position = self
                 .inner
-                .call_method(py, "seek", (offset, whence), None)
-                .map_err(pyerr_to_io_err)?;
+                .call_method1(py, "seek", (offset, whence))
+                .map_err(|e| pyerr_to_io_err(py, e))?;
 
-            new_position.extract(py).map_err(pyerr_to_io_err)
+            new_position.extract(py).map_err(|e| pyerr_to_io_err(py, e))
         })
+    }
+}
+
+impl Seek for PyFileLikeObject {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, io::Error> {
+        <&PyFileLikeObject>::seek(&mut &*self, pos)
     }
 }


### PR DESCRIPTION
### Breaking Changes

- `PyFileLikeObject::new` and `PyFileLikeObject::require` now take a `&PyAny` instead of a `PyObject`

### Added

- `PyFileLikeObject` now implements `FromPyObject`/`ToPyObject`, which allows it to be used directly as an argument to a pyfunction or as a return value
- New constructor `PyFileLikeObject::with_rw_seek` which takes const generic arguments to specify whether the object should be readable, writable and seekable, which can be used in `#[pyo3(from_py_with)]` when declaring the pyfunction or in a type deriving `FromPyObject`
- New functions `PyFileLikeObject::check_readable`, `PyFileLikeObject::check_writable` and `PyFileLikeObject::check_seekable` which can be used to check whether the object is readable, writable or seekable, respectively.
- `io::Error`s returned by the Read/Write/Seek implementations for `PyFileLikeObject` now pass along the original python exception, and attempt to set the error kind based on the `errno` field of the python exception, if present.
- `Read`, `Write`, and `Seek` are now additionally implemented for `&PyFileLikeObject` since they use the GIL for interior mutability.
- `PyFileLikeObject` now implements `Clone`, and provides a `clone_ref` method which can be used to clone the object more efficiently when already holding the GIL.
- New function `PyFileLikeObject::fileno` which attempts to call the fileno method on the underlying python object, and returns the result as a `i64` if successful.
- Add support for pyo3 0.20

### Fixes

- The `Read` implementation for `PyFileLikeObject` will now return errors rather than panicking if the underlying python object returns an unexpected type from the `read` python method.
- The `Write` implementation for `PyFileLikeObject` will now return errors rather than panicking when attempting to write non-utf8 bytes to a textio object.