### PR TITLE
Update the code example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ impl FileOrFileLike {
     pub fn from_pyobject(path_or_file_like: PyObject) -> PyResult<FileOrFileLike> {
         Python::with_gil(|py| {
             // is a path
-            if let Ok(string_ref) = path_or_file_like.downcast::<PyString>(py) {
+            if let Ok(string_ref) = path_or_file_like.downcast_bound::<PyString>(py) {
                 return Ok(FileOrFileLike::File(
                     string_ref.to_string_lossy().to_string(),
                 ));


### PR DESCRIPTION
`PyObject::downcast` is deprecated in favor of `PyObject::downcast_bound` since v0.23.0. ([v0.22 doc](https://docs.rs/pyo3/0.22.6/pyo3/prelude/type.PyObject.html#method.downcast), [v0.23 doc](https://docs.rs/pyo3/0.23/pyo3/prelude/type.PyObject.html#method.downcast_bound))