### PR TITLE
Implement `FromPyObject` for `PyFileLikeObject` and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,8 @@ impl<'py> FromPyObject<'py> for FileOrFileLike {
         }
 
         // is a file-like
-        match PyFileLikeObject::with_requirements(ob.clone().unbind(), true, false, true, false) {
-            Ok(f) => Ok(FileOrFileLike::FileLike(f)),
-            Err(e) => Err(e),
-        }
+        let f = PyFileLikeObject::py_with_requirements(ob.clone(), true, false, true, false)?;
+        Ok(FileOrFileLike::FileLike(f))
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -41,52 +41,41 @@ enum FileOrFileLike {
     FileLike(PyFileLikeObject),
 }
 
-impl FileOrFileLike {
-    pub fn from_pyobject(path_or_file_like: PyObject) -> PyResult<FileOrFileLike> {
-        Python::with_gil(|py| {
-            // is a path
-            if let Ok(string_ref) = path_or_file_like.downcast_bound::<PyString>(py) {
-                return Ok(FileOrFileLike::File(
-                    string_ref.to_string_lossy().to_string(),
-                ));
-            }
+impl<'py> FromPyObject<'py> for FileOrFileLike {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        // is a path
+        if let Ok(string) = ob.extract::<String>() {
+            return Ok(FileOrFileLike::File(string));
+        }
 
-            // is a file-like
-            match PyFileLikeObject::with_requirements(path_or_file_like, true, false, true, false) {
-                Ok(f) => Ok(FileOrFileLike::FileLike(f)),
-                Err(e) => Err(e)
-            }
-        })
+        // is a file-like
+        match PyFileLikeObject::with_requirements(ob.clone().unbind(), true, false, true, false) {
+            Ok(f) => Ok(FileOrFileLike::FileLike(f)),
+            Err(e) => Err(e),
+        }
     }
 }
 
 #[pyfunction]
 /// Opens a file or file-like, and reads it to string.
-fn accepts_path_or_file_like(
-    path_or_file_like: PyObject,
-) -> PyResult<String> {
-    Python::with_gil(|py| {
-        match FileOrFileLike::from_pyobject(path_or_file_like) {
-            Ok(f) => match f {
-                FileOrFileLike::File(s) => {
-                    println!("It's a file! - path {}", s);
-                    let mut f = File::open(s)?;
-                    let mut string = String::new();
+fn accepts_path_or_file_like(path_or_file_like: FileOrFileLike) -> PyResult<String> {
+    match path_or_file_like {
+        FileOrFileLike::File(s) => {
+            println!("It's a file! - path {}", s);
+            let mut f = File::open(s)?;
+            let mut string = String::new();
 
-                    let read = f.read_to_string(&mut string);
-                    Ok(string)
-                }
-                FileOrFileLike::FileLike(mut f) => {
-                    println!("Its a file-like object");
-                    let mut string = String::new();
-
-                    let read = f.read_to_string(&mut string);
-                    Ok(string)
-                }
-            },
-            Err(e) => Err(e),
+            f.read_to_string(&mut string)?;
+            Ok(string)
         }
-    })
+        FileOrFileLike::FileLike(mut f) => {
+            println!("Its a file-like object");
+            let mut string = String::new();
+
+            f.read_to_string(&mut string)?;
+            Ok(string)
+        }
+    }
 }
 
 #[pymodule]

--- a/examples/path_or_file_like/src/lib.rs
+++ b/examples/path_or_file_like/src/lib.rs
@@ -1,4 +1,3 @@
-use pyo3::types::PyString;
 use pyo3_file::PyFileLikeObject;
 
 use pyo3::prelude::*;
@@ -13,47 +12,40 @@ enum FileOrFileLike {
     FileLike(PyFileLikeObject),
 }
 
-impl FileOrFileLike {
-    pub fn from_pyobject(path_or_file_like: PyObject) -> PyResult<FileOrFileLike> {
-        Python::with_gil(|py| {
-            // is a path
-            if let Ok(string_ref) = path_or_file_like.downcast_bound::<PyString>(py) {
-                return Ok(FileOrFileLike::File(
-                    string_ref.to_string_lossy().to_string(),
-                ));
-            }
+impl<'py> FromPyObject<'py> for FileOrFileLike {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        // is a path
+        if let Ok(string) = ob.extract::<String>() {
+            return Ok(FileOrFileLike::File(string));
+        }
 
-            // is a file-like
-            match PyFileLikeObject::with_requirements(path_or_file_like, true, false, true, false) {
-                Ok(f) => Ok(FileOrFileLike::FileLike(f)),
-                Err(e) => Err(e),
-            }
-        })
+        // is a file-like
+        match PyFileLikeObject::with_requirements(ob.clone().unbind(), true, false, true, false) {
+            Ok(f) => Ok(FileOrFileLike::FileLike(f)),
+            Err(e) => Err(e),
+        }
     }
 }
 
 #[pyfunction]
 /// Opens a file or file-like, and reads it to string.
-fn accepts_path_or_file_like_read(path_or_file_like: PyObject) -> PyResult<String> {
-    match FileOrFileLike::from_pyobject(path_or_file_like) {
-        Ok(f) => match f {
-            FileOrFileLike::File(s) => {
-                println!("It's a file! - path {}", s);
-                let mut f = File::open(s)?;
-                let mut string = String::new();
+fn accepts_path_or_file_like_read(path_or_file_like: FileOrFileLike) -> PyResult<String> {
+    match path_or_file_like {
+        FileOrFileLike::File(s) => {
+            println!("It's a file! - path {}", s);
+            let mut f = File::open(s)?;
+            let mut string = String::new();
 
-                f.read_to_string(&mut string)?;
-                Ok(string)
-            }
-            FileOrFileLike::FileLike(mut f) => {
-                println!("Its a file-like object");
-                let mut string = String::new();
+            f.read_to_string(&mut string)?;
+            Ok(string)
+        }
+        FileOrFileLike::FileLike(mut f) => {
+            println!("Its a file-like object");
+            let mut string = String::new();
 
-                f.read_to_string(&mut string)?;
-                Ok(string)
-            }
-        },
-        Err(e) => Err(e),
+            f.read_to_string(&mut string)?;
+            Ok(string)
+        }
     }
 }
 

--- a/examples/path_or_file_like/src/lib.rs
+++ b/examples/path_or_file_like/src/lib.rs
@@ -20,10 +20,8 @@ impl<'py> FromPyObject<'py> for FileOrFileLike {
         }
 
         // is a file-like
-        match PyFileLikeObject::with_requirements(ob.clone().unbind(), true, false, true, false) {
-            Ok(f) => Ok(FileOrFileLike::FileLike(f)),
-            Err(e) => Err(e),
-        }
+        let f = PyFileLikeObject::py_with_requirements(ob.clone(), true, false, true, false)?;
+        Ok(FileOrFileLike::FileLike(f))
     }
 }
 
@@ -51,9 +49,9 @@ fn accepts_path_or_file_like_read(path_or_file_like: FileOrFileLike) -> PyResult
 
 #[pyfunction]
 /// Opens a file or file-like, and write a string to it.
-fn accepts_file_like_write(file_like: PyObject) -> PyResult<()> {
+fn accepts_file_like_write(file_like: Bound<PyAny>) -> PyResult<()> {
     // is a file-like
-    match PyFileLikeObject::with_requirements(file_like, false, true, false, false) {
+    match PyFileLikeObject::py_with_requirements(file_like, false, true, false, false) {
         Ok(mut f) => {
             println!("Its a file-like object");
             f.write_all(b"Hello, world!")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 use pyo3::{exceptions::PyTypeError, prelude::*};
 use std::borrow::Cow;
 
@@ -8,6 +10,7 @@ use std::io::{Read, Seek, SeekFrom, Write};
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, RawFd};
 
+/// A wrapper around a Python object that implements the file-like interface.
 #[derive(Debug)]
 pub struct PyFileLikeObject {
     // We use PyObject instead of Bound<PyAny> because Bound<PyAny> is a GIL-bound type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,12 @@ impl Clone for PyFileLikeObject {
 /// Wraps a `PyObject`, and implements read, seek, and write for it.
 impl PyFileLikeObject {
     /// Creates an instance of a `PyFileLikeObject` from a `PyObject`.
+    ///
     /// To assert the object has the required methods methods,
-    /// instantiate it with `PyFileLikeObject::require`
+    /// instantiate it with [`with_requirements`][Self::with_requirements].
+    ///
+    /// Prefer using [`py_new`][Self::py_new] if you already have a `Bound<PyAny>` object, as this
+    /// method re-acquires the GIL internally.
     pub fn new(object: PyObject) -> PyResult<Self> {
         Python::with_gil(|py| Self::py_new(object.into_bound(py)))
     }
@@ -38,6 +42,9 @@ impl PyFileLikeObject {
     /// Same as `PyFileLikeObject::new`, but validates that the underlying
     /// python object has a `read`, `write`, and `seek` methods in respect to parameters.
     /// Will return a `TypeError` if object does not have `read`, `seek`, `write` and `fileno` methods.
+    ///
+    /// Prefer using [`py_with_requirements`][Self::py_with_requirements] if you already have a
+    /// `Bound<PyAny>` object, as this method re-acquires the GIL internally.
     pub fn with_requirements(
         object: PyObject,
         read: bool,
@@ -49,9 +56,11 @@ impl PyFileLikeObject {
             Self::py_with_requirements(object.into_bound(py), read, write, seek, fileno)
         })
     }
-}
 
-impl PyFileLikeObject {
+    /// Creates an instance of a `PyFileLikeObject` from a `PyObject`.
+    ///
+    /// Prefer using this instead of [`new`][Self::new] if you already have a `Bound<PyAny>`
+    /// object, as this method does not acquire the GIL internally.
     pub fn py_new(obj: Bound<PyAny>) -> PyResult<Self> {
         let text_io = consts::text_io_base(obj.py())?;
         let is_text_io = obj.is_instance(text_io)?;
@@ -62,6 +71,10 @@ impl PyFileLikeObject {
         })
     }
 
+    /// Creates an instance of a `PyFileLikeObject` from a `PyObject`.
+    ///
+    /// Prefer using this instead of [`with_requirements`][Self::with_requirements] if you already
+    /// have a `Bound<PyAny>` object, as this method does not acquire the GIL internally.
     pub fn py_with_requirements(
         obj: Bound<PyAny>,
         read: bool,
@@ -230,6 +243,12 @@ impl AsRawFd for PyFileLikeObject {
 impl AsRawFd for &PyFileLikeObject {
     fn as_raw_fd(&self) -> RawFd {
         Python::with_gil(|py| self.py_as_raw_fd(py))
+    }
+}
+
+impl<'py> FromPyObject<'py> for PyFileLikeObject {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        Self::py_new(ob.clone())
     }
 }
 


### PR DESCRIPTION
- Update example to implement `FromPyObject` for `FileOrFileLike` instead of custom `from_pyobject` method. This means we can use `FileOrFileLike` as a type in the signature directly:

	```rs
	fn accepts_path_or_file_like(path_or_file_like: FileOrFileLike) -> PyResult<String>
	```

- Implement `FromPyObject` for `PyFileLikeObject`, so that users can similarly put `PyFileLikeObject` directly in a signature.
- Update README to use latest example
- Don't use `match` for error handling
- Document preference to use `py_new` instead of `new` and `py_with_requirements` instead of `with_requirements` to avoid re-acquiring GIL
- Include README in `lib.rs` for improved crate docs: 
<img width="1284" alt="image" src="https://github.com/user-attachments/assets/1591d156-8e54-46f3-a7dd-e4bfc90a4835" />
