### PR TITLE
Bump pyo3-file to 0.15.0 for pyo3 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/omerbenamram/pyo3-file"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Omer Ben-Amram <omerbenamram@gmail.com>"]
 edition = "2018"
 

--- a/examples/path_or_file_like/Cargo.lock
+++ b/examples/path_or_file_like/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "pyo3-file"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "pyo3",
  "skeptic",


### PR DESCRIPTION
## Summary\n- bump crate version from 0.14.0 to 0.15.0\n- update example lockfile to reference the new crate version\n\nCloses #33\n\n## Validation\n- cargo check\n- cargo check --manifest-path examples/path_or_file_like/Cargo.toml\n- python3 -m venv .venv-ci && .venv-ci/bin/python -m pip install -U pip setuptools wheel pytest maturin\n- .venv-ci/bin/python -m maturin build -m ./examples/path_or_file_like/Cargo.toml -o ./examples/path_or_file_like/wheels\n- .venv-ci/bin/python -m pip install --force-reinstall ./examples/path_or_file_like/wheels/*.whl\n- .venv-ci/bin/python -m pytest ./examples/path_or_file_like\n